### PR TITLE
Use os.pread or a lock in MODE_FILE

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -6,6 +6,8 @@ History
 1.2.0 (2015-04-XX)
 ++++++++++++++++++
 
+* The ``Metadata`` class now overloads ``__repr__`` to provide a useful
+  representation of the contents when debugging.
 * An ``InvalidDatabaseError`` will now be thrown if the data type read from
   the database is invalid. Previously a ``KeyError`` was thrown.
 

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -3,6 +3,12 @@
 History
 -------
 
+1.2.0 (2015-04-XX)
+++++++++++++++++++
+
+* An ``InvalidDatabaseError`` will now be thrown if the data type read from
+  the database is invalid. Previously a ``KeyError`` was thrown.
+
 1.1.1 (2014-12-10)
 ++++++++++++++++++
 

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -6,6 +6,14 @@ History
 1.2.0 (2015-04-XX)
 ++++++++++++++++++
 
+* Previously if ``MODE_FILE`` was used and the database was loaded before
+  forking, the parent and children would use the same file table entry without
+  locking causing errors reading the database due to the offset being changed
+  by other processes. In ``MODE_FILE``, the reader will now use ``os.pread``
+  when available and a lock when ``os.pread`` is not available (e.g., Python
+  2). If you are using ``MODE_FILE`` on a Python without ``os.pread``, it is
+  recommended that you open the database after forking to reduce resource
+  contention.
 * The ``Metadata`` class now overloads ``__repr__`` to provide a useful
   representation of the contents when debugging.
 * An ``InvalidDatabaseError`` will now be thrown if the data type read from

--- a/maxminddb/compat.py
+++ b/maxminddb/compat.py
@@ -2,19 +2,10 @@ import sys
 
 # pylint: skip-file
 
-is_py2 = sys.version_info[0] == 2
-
-is_py3_3_or_better = (
-    sys.version_info[0] >= 3 and sys.version_info[1] >= 3)
-
-if is_py2 and not is_py3_3_or_better:
+if sys.version_info[0] == 2:
     import ipaddr as ipaddress  # pylint:disable=F0401
     ipaddress.ip_address = ipaddress.IPAddress
-else:
-    import ipaddress  # pylint:disable=F0401
 
-
-if is_py2:
     int_from_byte = ord
 
     FileNotFoundError = IOError
@@ -25,8 +16,9 @@ if is_py2:
         return 0
 
     byte_from_int = chr
-
 else:
+    import ipaddress  # pylint:disable=F0401
+
     int_from_byte = lambda x: x
 
     FileNotFoundError = FileNotFoundError

--- a/maxminddb/decoder.py
+++ b/maxminddb/decoder.py
@@ -126,6 +126,10 @@ class Decoder(object):  # pylint: disable=too-few-public-methods
         if not type_num:
             (type_num, new_offset) = self._read_extended(new_offset)
 
+        if not type_num in self._type_decoder:
+            raise InvalidDatabaseError('Unexpected type number ({type}) '
+                                       'encountered'.format(type=type_num))
+
         (size, new_offset) = self._size_from_ctrl_byte(
             ctrl_byte, new_offset, type_num)
         return self._type_decoder[type_num](self, size, new_offset)

--- a/maxminddb/reader.py
+++ b/maxminddb/reader.py
@@ -76,7 +76,8 @@ class Reader(object):
         metadata_start += len(self._METADATA_START_MARKER)
         metadata_decoder = Decoder(self._buffer, metadata_start)
         (metadata, _) = metadata_decoder.decode(metadata_start)
-        self._metadata = Metadata(**metadata)  # pylint: disable=star-args
+        self._metadata = Metadata(
+            **metadata)  # pylint: disable=bad-option-value
 
         self._decoder = Decoder(self._buffer, self._metadata.search_tree_size
                                 + self._DATA_SECTION_SEPARATOR_SIZE)
@@ -176,6 +177,7 @@ class Reader(object):
 
     def close(self):
         """Closes the MaxMind DB file and returns the resources to the system"""
+        # pylint: disable=unidiomatic-typecheck
         if type(self._buffer) not in (str, bytes):
             self._buffer.close()
 
@@ -210,3 +212,10 @@ class Metadata(object):
     def search_tree_size(self):
         """The size of the search tree"""
         return self.node_count * self.node_byte_size
+
+    def __repr__(self):
+        args = ', '.join('%s=%r' % x for x in self.__dict__.items())
+        return '{module}.{class_name}({data})'.format(
+            module=self.__module__,
+            class_name=self.__class__.__name__,
+            data=args)


### PR DESCRIPTION
After a fork, the file handle of both the parent and child process will share the same file table entry, which holds state such as the offset. There is unfortunately no way to clone the file table entry (dup only duplicates the file descriptor). This leads to corrupted reads when another process changes the offset unexpectedly. In Python 3.x, we use `pread` when available, as it does not rely on the offset in the file table. On Python's without `pread`, we rely on a lock. Reported in [#22 on GeoIP2-python](https://github.com/maxmind/GeoIP2-python/issues/22).