### PR TITLE
Implemented Issue #13 - Add reader mode information to reader object

### DIFF
--- a/maxminddb/__init__.py
+++ b/maxminddb/__init__.py
@@ -29,7 +29,7 @@ def open_database(database, mode=MODE_AUTO):
     """
     if (mode == MODE_AUTO and maxminddb.extension and
             hasattr(maxminddb.extension, 'Reader')) or mode == MODE_MMAP_EXT:
-        return maxminddb.extension.Reader(database)
+        return maxminddb.extension.Reader(database, mode)
     elif mode in (MODE_AUTO, MODE_MMAP, MODE_FILE, MODE_MEMORY):
         return maxminddb.reader.Reader(database, mode)
     raise ValueError('Unsupported open mode: {0}'.format(mode))

--- a/maxminddb/reader.py
+++ b/maxminddb/reader.py
@@ -46,18 +46,22 @@ class Reader(object):
             * MODE_MEMORY - load database into memory.
             * MODE_AUTO - tries MODE_MMAP and then MODE_FILE. Default.
         """
+        metadata_mode_auto = mode == MODE_AUTO
         if (mode == MODE_AUTO and mmap) or mode == MODE_MMAP:
             with open(database, 'rb') as db_file:
                 self._buffer = mmap.mmap(
                     db_file.fileno(), 0, access=mmap.ACCESS_READ)
                 self._buffer_size = self._buffer.size()
+            metadata_mode = 'MODE_MMAP'
         elif mode in (MODE_AUTO, MODE_FILE):
             self._buffer = FileBuffer(database)
             self._buffer_size = self._buffer.size()
+            metadata_mode = 'MODE_FILE'
         elif mode == MODE_MEMORY:
             with open(database, 'rb') as db_file:
                 self._buffer = db_file.read()
                 self._buffer_size = len(self._buffer)
+            metadata_mode = 'MODE_MEMORY'
         else:
             raise ValueError('Unsupported open mode ({0}). Only MODE_AUTO, '
                              ' MODE_FILE, and MODE_MEMORY are support by the pure Python '
@@ -76,6 +80,8 @@ class Reader(object):
         metadata_start += len(self._METADATA_START_MARKER)
         metadata_decoder = Decoder(self._buffer, metadata_start)
         (metadata, _) = metadata_decoder.decode(metadata_start)
+        metadata['mode_auto'] = metadata_mode_auto
+        metadata['mode'] = metadata_mode
         self._metadata = Metadata(
             **metadata)  # pylint: disable=bad-option-value
 
@@ -202,6 +208,8 @@ class Metadata(object):
             'binary_format_minor_version']
         self.build_epoch = kwargs['build_epoch']
         self.description = kwargs['description']
+        self.mode_auto = kwargs.get('mode_auto', None)
+        self.mode = kwargs.get('mode', None)
 
     @property
     def node_byte_size(self):

--- a/maxminddb/reader.py
+++ b/maxminddb/reader.py
@@ -46,22 +46,22 @@ class Reader(object):
             * MODE_MEMORY - load database into memory.
             * MODE_AUTO - tries MODE_MMAP and then MODE_FILE. Default.
         """
-        metadata_mode_auto = mode == MODE_AUTO
+        self.mode_auto = mode == MODE_AUTO
         if (mode == MODE_AUTO and mmap) or mode == MODE_MMAP:
             with open(database, 'rb') as db_file:
                 self._buffer = mmap.mmap(
                     db_file.fileno(), 0, access=mmap.ACCESS_READ)
                 self._buffer_size = self._buffer.size()
-            metadata_mode = 'MODE_MMAP'
+            self.mode = 'MODE_MMAP'
         elif mode in (MODE_AUTO, MODE_FILE):
             self._buffer = FileBuffer(database)
             self._buffer_size = self._buffer.size()
-            metadata_mode = 'MODE_FILE'
+            self.mode = 'MODE_FILE'
         elif mode == MODE_MEMORY:
             with open(database, 'rb') as db_file:
                 self._buffer = db_file.read()
                 self._buffer_size = len(self._buffer)
-            metadata_mode = 'MODE_MEMORY'
+            self.mode = 'MODE_MEMORY'
         else:
             raise ValueError('Unsupported open mode ({0}). Only MODE_AUTO, '
                              ' MODE_FILE, and MODE_MEMORY are support by the pure Python '
@@ -80,8 +80,6 @@ class Reader(object):
         metadata_start += len(self._METADATA_START_MARKER)
         metadata_decoder = Decoder(self._buffer, metadata_start)
         (metadata, _) = metadata_decoder.decode(metadata_start)
-        metadata['mode_auto'] = metadata_mode_auto
-        metadata['mode'] = metadata_mode
         self._metadata = Metadata(
             **metadata)  # pylint: disable=bad-option-value
 
@@ -208,8 +206,6 @@ class Metadata(object):
             'binary_format_minor_version']
         self.build_epoch = kwargs['build_epoch']
         self.description = kwargs['description']
-        self.mode_auto = kwargs.get('mode_auto', None)
-        self.mode = kwargs.get('mode', None)
 
     @property
     def node_byte_size(self):


### PR DESCRIPTION
Re-do of pull request #14. Implemented issue #13. Also rebased to master so that it's merge-able. Compiled libmaxminddb locally, compiled maxminddb.extension against it locally, and tested with all modes explicit and with `MODE_AUTO`. Works great!

My only concern now is that, in pull request #14, I could access the mode with this:

``` python
reader.metadata().mode
```

But now I have to do this:

``` python
reader._db_reader.mode
```

That's violating best practices by accessing a "private" variable. Suggestions?
