### PR TITLE
Use ipaddress on both Python 2 and 3

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -83,7 +83,7 @@ Requirements
 This code requires Python 2.6+ or 3.3+. The C extension requires CPython. The
 pure Python implementation has been tested with PyPy.
 
-On Python 2, the `ipaddr module <https://code.google.com/p/ipaddr-py/>`_ is
+On Python 2, the `ipaddress module <https://pypi.python.org/pypi/ipaddress>`_ is
 required.
 
 Versioning

--- a/maxminddb/compat.py
+++ b/maxminddb/compat.py
@@ -3,9 +3,6 @@ import sys
 # pylint: skip-file
 
 if sys.version_info[0] == 2:
-    import ipaddr as ipaddress  # pylint:disable=F0401
-    ipaddress.ip_address = ipaddress.IPAddress
-
     int_from_byte = ord
 
     FileNotFoundError = IOError
@@ -17,7 +14,6 @@ if sys.version_info[0] == 2:
 
     byte_from_int = chr
 else:
-    import ipaddress  # pylint:disable=F0401
 
     int_from_byte = lambda x: x
 

--- a/maxminddb/reader.py
+++ b/maxminddb/reader.py
@@ -15,7 +15,8 @@ except ImportError:
 
 import struct
 
-from maxminddb.compat import byte_from_int, int_from_byte, ipaddress
+import ipaddress
+from maxminddb.compat import byte_from_int, int_from_byte
 from maxminddb.const import MODE_AUTO, MODE_MMAP, MODE_FILE, MODE_MEMORY
 from maxminddb.decoder import Decoder
 from maxminddb.errors import InvalidDatabaseError

--- a/maxminddb/reader.py
+++ b/maxminddb/reader.py
@@ -15,7 +15,7 @@ except ImportError:
 
 import struct
 
-import ipaddress
+import ipaddress  # pylint:disable=F0401
 from maxminddb.compat import byte_from_int, int_from_byte
 from maxminddb.const import MODE_AUTO, MODE_MMAP, MODE_FILE, MODE_MEMORY
 from maxminddb.decoder import Decoder

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ requirements = []
 
 if sys.version_info[0] == 2 or (sys.version_info[0] == 3
                                 and sys.version_info[1] < 3):
-    requirements.append('ipaddr')
+    requirements.append('ipaddress')
 
 compile_args = ['-Wall', '-Wextra']
 


### PR DESCRIPTION
A 1:1 backport is available and allows a single dependency tree to support both versions of python (`ipaddr` fails to install under Python 3).