### PR TITLE
Use backport of ipaddress for Python 2 instead of ipaddr

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -83,7 +83,7 @@ Requirements
 This code requires Python 2.6+ or 3.3+. The C extension requires CPython. The
 pure Python implementation has been tested with PyPy.
 
-On Python 2, the `ipaddr module <https://code.google.com/p/ipaddr-py/>`_ is
+On Python 2, the `ipaddress module <https://pypi.python.org/pypi/ipaddress>`_ is
 required.
 
 Versioning

--- a/maxminddb/compat.py
+++ b/maxminddb/compat.py
@@ -3,9 +3,6 @@ import sys
 # pylint: skip-file
 
 if sys.version_info[0] == 2:
-    import ipaddr as ipaddress  # pylint:disable=F0401
-    ipaddress.ip_address = ipaddress.IPAddress
-
     int_from_byte = ord
 
     FileNotFoundError = IOError
@@ -17,8 +14,6 @@ if sys.version_info[0] == 2:
 
     byte_from_int = chr
 else:
-    import ipaddress  # pylint:disable=F0401
-
     int_from_byte = lambda x: x
 
     FileNotFoundError = FileNotFoundError

--- a/maxminddb/compat.py
+++ b/maxminddb/compat.py
@@ -1,8 +1,15 @@
 import sys
 
+import ipaddress
+
 # pylint: skip-file
 
 if sys.version_info[0] == 2:
+    def compat_ip_address(address):
+        if isinstance(address, bytes):
+            address = address.decode()
+        return ipaddress.ip_address(address)
+
     int_from_byte = ord
 
     FileNotFoundError = IOError
@@ -14,6 +21,9 @@ if sys.version_info[0] == 2:
 
     byte_from_int = chr
 else:
+    def compat_ip_address(address):
+        return ipaddress.ip_address(address)
+
     int_from_byte = lambda x: x
 
     FileNotFoundError = FileNotFoundError

--- a/maxminddb/reader.py
+++ b/maxminddb/reader.py
@@ -14,9 +14,8 @@ except ImportError:
     mmap = None
 
 import struct
-import ipaddress
 
-from maxminddb.compat import byte_from_int, int_from_byte
+from maxminddb.compat import byte_from_int, int_from_byte, compat_ip_address
 from maxminddb.const import MODE_AUTO, MODE_MMAP, MODE_FILE, MODE_MEMORY
 from maxminddb.decoder import Decoder
 from maxminddb.errors import InvalidDatabaseError
@@ -47,7 +46,6 @@ class Reader(object):
             * MODE_MEMORY - load database into memory.
             * MODE_AUTO - tries MODE_MMAP and then MODE_FILE. Default.
         """
-        # pylint: disable=redefined-variable-type
         if (mode == MODE_AUTO and mmap) or mode == MODE_MMAP:
             with open(database, 'rb') as db_file:
                 self._buffer = mmap.mmap(
@@ -95,10 +93,8 @@ class Reader(object):
         Arguments:
         ip_address -- an IP address in the standard string notation
         """
-        if isinstance(ip_address, bytes):
-            ip_address = ip_address.decode()
 
-        address = ipaddress.ip_address(ip_address)
+        address = compat_ip_address(ip_address)
 
         if address.version == 6 and self._metadata.ip_version == 4:
             raise ValueError('Error looking up {0}. You attempted to look up '

--- a/maxminddb/reader.py
+++ b/maxminddb/reader.py
@@ -95,6 +95,9 @@ class Reader(object):
         Arguments:
         ip_address -- an IP address in the standard string notation
         """
+        if isinstance(ip_address, bytes):
+            ip_address = ip_address.decode()
+
         address = ipaddress.ip_address(ip_address)
 
         if address.version == 6 and self._metadata.ip_version == 4:

--- a/maxminddb/reader.py
+++ b/maxminddb/reader.py
@@ -14,8 +14,9 @@ except ImportError:
     mmap = None
 
 import struct
+import ipaddress
 
-from maxminddb.compat import byte_from_int, int_from_byte, ipaddress
+from maxminddb.compat import byte_from_int, int_from_byte
 from maxminddb.const import MODE_AUTO, MODE_MMAP, MODE_FILE, MODE_MEMORY
 from maxminddb.decoder import Decoder
 from maxminddb.errors import InvalidDatabaseError

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ requirements = []
 
 if sys.version_info[0] == 2 or (sys.version_info[0] == 3
                                 and sys.version_info[1] < 3):
-    requirements.append('ipaddr')
+    requirements.append('ipaddress')
 
 compile_args = ['-Wall', '-Wextra']
 


### PR DESCRIPTION
Port of the 3.3+ ipaddress module to 2.6, 2.7, 3.2 now available, simplifies dependencies for end users who now have to have ipaddress and ipaddr installed to use this.