### PR TITLE
Run snyk checks on requirements, but only for python 2.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,15 +36,12 @@ before_install:
     if [[ $TRAVIS_PYTHON_VERSION == '2.7' ]]; then
       sudo apt-get install -y nodejs;
       npm install -g snyk;
-      pip install -r requirements.txt;
     fi
-
-install:
-  - if [[ $TRAVIS_PYTHON_VERSION == '2.7' ]]; then snyk test --org=maxmind; fi
 
 script:
   - if [[ $TRAVIS_PYTHON_VERSION != 'pypy' ]]; then export MM_FORCE_EXT_TESTS=1; fi
   - CFLAGS="-Werror -Wall -Wextra" coverage run --source maxminddb setup.py test
+  - if [[ $TRAVIS_PYTHON_VERSION == '2.7' ]]; then snyk test --org=maxmind --file=requirements.txt; fi
   - if [[ $TRAVIS_PYTHON_VERSION == '3.7' ]]; then pylint --rcfile .pylintrc maxminddb/*.py; fi
   - if [[ $TRAVIS_PYTHON_VERSION == '3.7' ]]; then ./.travis-yapf.sh; fi
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,24 @@
 language: python
-
-python:
-  - 2.6
-  - 2.7
-  - 3.3
-  - 3.4
-  - 3.5
-  - 3.6
-  - 3.7-dev
-  - pypy
+matrix:
+  include:
+    - python: 2.7
+      dist: trusty
+    - python: 3.3
+      dist: trusty
+    - python: 3.4
+      dist: trusty
+    - python: 3.5
+      dist: trusty
+    - python: 3.6
+      dist: trusty
+    - python: 3.7
+      dist: xenial
+    - python: nightly
+      dist: xenial
+    - python: pypy
+      dist: trusty
+  allow_failures:
+    - python: nightly
 
 before_install:
   - git submodule update --init --recursive
@@ -21,7 +31,7 @@ before_install:
   - sudo ldconfig
   - cd ..
   - pip install coverage coveralls
-  - if [[ $TRAVIS_PYTHON_VERSION == '3.6' ]]; then pip install pylint yapf; fi
+  - if [[ $TRAVIS_PYTHON_VERSION == '3.7' ]]; then pip install pylint yapf; fi
   - if [[ $TRAVIS_PYTHON_VERSION == '2.6' ]]; then pip install unittest2; fi
   - |
     if [[ $TRAVIS_PYTHON_VERSION == '2.7' ]]; then
@@ -36,8 +46,8 @@ install:
 script:
   - if [[ $TRAVIS_PYTHON_VERSION != 'pypy' ]]; then export MM_FORCE_EXT_TESTS=1; fi
   - CFLAGS="-Werror -Wall -Wextra" coverage run --source maxminddb setup.py test
-  - if [[ $TRAVIS_PYTHON_VERSION == '3.6' ]]; then pylint --rcfile .pylintrc maxminddb/*.py; fi
-  - if [[ $TRAVIS_PYTHON_VERSION == '3.6' ]]; then ./.travis-yapf.sh; fi
+  - if [[ $TRAVIS_PYTHON_VERSION == '3.7' ]]; then pylint --rcfile .pylintrc maxminddb/*.py; fi
+  - if [[ $TRAVIS_PYTHON_VERSION == '3.7' ]]; then ./.travis-yapf.sh; fi
 
 after_success:
   - coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,6 @@ before_install:
   - cd ..
   - pip install coverage coveralls
   - if [[ $TRAVIS_PYTHON_VERSION == '3.7' ]]; then pip install pylint yapf; fi
-  - if [[ $TRAVIS_PYTHON_VERSION == '2.6' ]]; then pip install unittest2; fi
   - |
     if [[ $TRAVIS_PYTHON_VERSION == '2.7' ]]; then
       sudo apt-get install -y nodejs;

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,15 @@ before_install:
   - pip install coverage coveralls
   - if [[ $TRAVIS_PYTHON_VERSION == '3.6' ]]; then pip install pylint yapf; fi
   - if [[ $TRAVIS_PYTHON_VERSION == '2.6' ]]; then pip install unittest2; fi
+  - |
+    if [[ $TRAVIS_PYTHON_VERSION == '2.7' ]]; then
+      sudo apt-get install -y nodejs;
+      npm install -g snyk;
+      pip install -r requirements.txt;
+    fi
+
+install:
+  - if [[ $TRAVIS_PYTHON_VERSION == '2.7' ]]; then snyk test --org=maxmind; fi
 
 script:
   - if [[ $TRAVIS_PYTHON_VERSION != 'pypy' ]]; then export MM_FORCE_EXT_TESTS=1; fi
@@ -32,6 +41,7 @@ script:
 
 after_success:
   - coveralls
+  - if [[ $TRAVIS_BRANCH == 'master' && $TRAVIS_PULL_REQUEST == 'false' && $TRAVIS_PYTHON_VERSION == '2.7' ]]; then snyk monitor --org=maxmind --project=maxmind/MaxMind-DB-Reader-python; fi
 
 notifications:
   email:
@@ -42,7 +52,8 @@ notifications:
 
 env:
   global:
-   - secure: "pVcpV/al5Q607TbRzl/sbkdsx5hUjxehaJm6t5tgWrFn45icwdZrPw3JWcpt0R57NhPvXHxcJdm4WBtcGElWoDtR52QOW3yYh+gRw23y1MJg+5qHIbh5R1sOC/fLJ9TzQzvvRH5QQ5bKIe1hRQW9Cpqm7nX5Zhq6SqnAzcG1emE="
+    - secure: "pVcpV/al5Q607TbRzl/sbkdsx5hUjxehaJm6t5tgWrFn45icwdZrPw3JWcpt0R57NhPvXHxcJdm4WBtcGElWoDtR52QOW3yYh+gRw23y1MJg+5qHIbh5R1sOC/fLJ9TzQzvvRH5QQ5bKIe1hRQW9Cpqm7nX5Zhq6SqnAzcG1emE="
+    - secure: "idzTTvCWmC0TYgYxQFOaZju86TUzKLaMKs2ZZsGloklf0mk0d3XH/CD5VYDPgP++/7Kmw9zC401EZyRC6anZYB0qCXwRulgux2Io5HCWChIrZTSx3DoSl+VRVi0cUkfMNomrwduJ0g1vVnDXp6xM8ITE574jwpasUJ2MOvVykdU="
 
 addons:
   coverity_scan:

--- a/README.rst
+++ b/README.rst
@@ -85,7 +85,7 @@ invalid IP address or an IPv6 address in an IPv4 database.
 Requirements
 ------------
 
-This code requires Python 2.6+ or 3.3+. The C extension requires CPython. The
+This code requires Python 2.7+ or 3.3+. The C extension requires CPython. The
 pure Python implementation has been tested with PyPy.
 
 On Python 2, the `ipaddress module <https://pypi.python.org/pypi/ipaddress>`_ is

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,0 @@
-# NOTE: This project does not use requirements.txt, it uses setup.py.
-# This file is only present to support dependency checks in CI for certain
-# python versions.
-ipaddress

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+# NOTE: This project does not use requirements.txt, it uses setup.py.
+# This file is only present to support dependency checks in CI for certain
+# python versions.
+ipaddress

--- a/setup.py
+++ b/setup.py
@@ -20,8 +20,9 @@ if sys.version_info[0] == 2 or (sys.version_info[0] == 3
                                 and sys.version_info[1] < 3):
     requirements.append('ipaddress')
     if os.environ.get('SNYK_TOKEN'):
-        f = open('requirements.txt', 'w')
-        [f.write(r + '\n') for r in requirements]
+        with open('requirements.txt', 'w') as f:
+            for r in requirements:
+                f.write(r + '\n')
 
 compile_args = ['-Wall', '-Wextra']
 
@@ -145,6 +146,8 @@ def run_setup(with_cext):
             'Programming Language :: Python :: 3.3',
             'Programming Language :: Python :: 3.4',
             'Programming Language :: Python :: 3.5',
+            'Programming Language :: Python :: 3.6',
+            'Programming Language :: Python :: 3.7',
             'Programming Language :: Python',
             'Topic :: Internet :: Proxy Servers',
             'Topic :: Internet',

--- a/setup.py
+++ b/setup.py
@@ -37,11 +37,6 @@ ext_module = [
 # Cargo cult code for installing extension with pure Python fallback.
 # Taken from SQLAlchemy, but this same basic code exists in many modules.
 ext_errors = (CCompilerError, DistutilsExecError, DistutilsPlatformError)
-if sys.platform == 'win32':
-    # 2.6's distutils.msvc9compiler can raise an IOError when failing to
-    # find the compiler
-    ext_errors += (IOError, )
-
 
 class BuildFailed(Exception):
     def __init__(self):
@@ -141,7 +136,6 @@ def run_setup(with_cext):
             'Intended Audience :: Developers',
             'Intended Audience :: System Administrators',
             'License :: OSI Approved :: Apache Software License',
-            'Programming Language :: Python :: 2.6',
             'Programming Language :: Python :: 2.7',
             'Programming Language :: Python :: 3',
             'Programming Language :: Python :: 3.3',

--- a/setup.py
+++ b/setup.py
@@ -19,6 +19,9 @@ requirements = []
 if sys.version_info[0] == 2 or (sys.version_info[0] == 3
                                 and sys.version_info[1] < 3):
     requirements.append('ipaddress')
+    if os.environ.get('SNYK_TOKEN'):
+        f = open('requirements.txt', 'w')
+        [f.write(r + '\n') for r in requirements]
 
 compile_args = ['-Wall', '-Wextra']
 
@@ -37,6 +40,7 @@ ext_module = [
 # Cargo cult code for installing extension with pure Python fallback.
 # Taken from SQLAlchemy, but this same basic code exists in many modules.
 ext_errors = (CCompilerError, DistutilsExecError, DistutilsPlatformError)
+
 
 class BuildFailed(Exception):
     def __init__(self):

--- a/tests/decoder_test.py
+++ b/tests/decoder_test.py
@@ -9,10 +9,7 @@ import sys
 from maxminddb.compat import byte_from_int, int_from_byte
 from maxminddb.decoder import Decoder
 
-if sys.version_info[:2] == (2, 6):
-    import unittest2 as unittest
-else:
-    import unittest
+import unittest
 
 if sys.version_info[0] == 2:
     unittest.TestCase.assertRaisesRegex = unittest.TestCase.assertRaisesRegexp


### PR DESCRIPTION
- snyk needs to check requirements.txt, so add one, but be warned it
  isn't actually used as part of installing this project's dependencies;
  see setup.py
- setup.py needs ipaddress for all python 2.x and python <3.3, but we're
  only testing 3.x for versions 3.3 or greater. Therefore only check 2.7
  since we'd expect the same snyk result for all python 2.x versions.