### PR TITLE
Support ipaddress objects in "get" method

### DIFF
--- a/extension/maxminddb.c
+++ b/extension/maxminddb.c
@@ -182,16 +182,14 @@ static PyObject *Reader_get(PyObject *self, PyObject *args)
         MMDB_lookup_string(mmdb, ip_address, &gai_error,
                            &mmdb_error);
 
-#if PY_MAJOR_VERSION >= 3
-    if (bytes != NULL) {
-        Py_DECREF(bytes);
-    }
-#endif
-
     if (0 != gai_error) {
         PyErr_Format(PyExc_ValueError,
                      "'%s' does not appear to be an IPv4 or IPv6 address.",
                      ip_address);
+
+#if PY_MAJOR_VERSION >= 3
+        Py_XDECREF(bytes);
+#endif
         return NULL;
     }
 
@@ -204,6 +202,9 @@ static PyObject *Reader_get(PyObject *self, PyObject *args)
         }
         PyErr_Format(exception, "Error looking up %s. %s",
                      ip_address, MMDB_strerror(mmdb_error));
+#if PY_MAJOR_VERSION >= 3
+        Py_XDECREF(bytes);
+#endif
         return NULL;
     }
 
@@ -218,8 +219,15 @@ static PyObject *Reader_get(PyObject *self, PyObject *args)
                      "Error while looking up data for %s. %s",
                      ip_address, MMDB_strerror(status));
         MMDB_free_entry_data_list(entry_data_list);
+#if PY_MAJOR_VERSION >= 3
+        Py_XDECREF(bytes);
+#endif
         return NULL;
     }
+
+#if PY_MAJOR_VERSION >= 3
+    Py_XDECREF(bytes);
+#endif
 
     MMDB_entry_data_list_s *original_entry_data_list = entry_data_list;
     PyObject *py_obj = from_entry_data_list(&entry_data_list);

--- a/extension/maxminddb.c
+++ b/extension/maxminddb.c
@@ -148,7 +148,7 @@ static PyObject *Reader_get(PyObject *self, PyObject *args)
         PyObject *str;
 
         if (!is_ipaddress_object) {
-            PyErr_SetString(PyExc_TypeError, "IP address must be a string, "
+            PyErr_SetString(PyExc_TypeError, "IP address must be a string,"
                 " ipaddress.IPv4Address or ipaddress.IPv6Address object");
         } else if ((str = PyObject_Str(object)) != NULL) {
 #if PY_MAJOR_VERSION > 2

--- a/extension/maxminddb.c
+++ b/extension/maxminddb.c
@@ -108,7 +108,7 @@ static PyObject *Reader_get(PyObject *self, PyObject *args)
 {
     char *ip_address = NULL;
     PyObject *object = NULL;
-#if PY_MAJOR_VERSION > 2
+#if PY_MAJOR_VERSION >= 3
     PyObject *bytes = NULL;
 #endif
 
@@ -151,7 +151,7 @@ static PyObject *Reader_get(PyObject *self, PyObject *args)
             PyErr_SetString(PyExc_TypeError, "IP address must be a string,"
                 " ipaddress.IPv4Address or ipaddress.IPv6Address object");
         } else if ((str = PyObject_Str(object)) != NULL) {
-#if PY_MAJOR_VERSION > 2
+#if PY_MAJOR_VERSION >= 3
             bytes = PyUnicode_AsEncodedString(str, "UTF-8", "strict");
             ip_address = PyBytes_AS_STRING(bytes);
 #else
@@ -182,7 +182,7 @@ static PyObject *Reader_get(PyObject *self, PyObject *args)
         MMDB_lookup_string(mmdb, ip_address, &gai_error,
                            &mmdb_error);
 
-#if PY_MAJOR_VERSION > 2
+#if PY_MAJOR_VERSION >= 3
     if (bytes != NULL) {
         Py_DECREF(bytes);
     }

--- a/maxminddb/reader.py
+++ b/maxminddb/reader.py
@@ -108,12 +108,12 @@ class Reader(object):
         """
         if isinstance(ip_address,
             (ipaddress.IPv4Address, ipaddress.IPv6Address)):
-            ip_address = str(ip_address)
+            address = str(ip_address)
         elif not isinstance(ip_address, string_type):
             raise TypeError('argument 1 must be %s, not %s' %
                             (string_type_name, type(ip_address).__name__))
-
-        address = compat_ip_address(ip_address)
+        else:
+            address = compat_ip_address(ip_address)
 
         if address.version == 6 and self._metadata.ip_version == 4:
             raise ValueError(

--- a/maxminddb/reader.py
+++ b/maxminddb/reader.py
@@ -107,7 +107,7 @@ class Reader(object):
         ip_address -- an IP address in the standard string notation
         """
         if isinstance(ip_address,
-            (ipaddress.IPv4Address, ipaddress.IPv6Address)):
+                      (ipaddress.IPv4Address, ipaddress.IPv6Address)):
             address = ip_address
         elif not isinstance(ip_address, string_type):
             raise TypeError('argument 1 must be %s, not %s' %

--- a/maxminddb/reader.py
+++ b/maxminddb/reader.py
@@ -108,7 +108,7 @@ class Reader(object):
         """
         if isinstance(ip_address,
             (ipaddress.IPv4Address, ipaddress.IPv6Address)):
-            address = str(ip_address)
+            address = ip_address
         elif not isinstance(ip_address, string_type):
             raise TypeError('argument 1 must be %s, not %s' %
                             (string_type_name, type(ip_address).__name__))

--- a/maxminddb/reader.py
+++ b/maxminddb/reader.py
@@ -13,6 +13,7 @@ except ImportError:
     # pylint: disable=invalid-name
     mmap = None
 
+import ipaddress
 import struct
 
 from maxminddb.compat import (byte_from_int, compat_ip_address, string_type,
@@ -105,7 +106,10 @@ class Reader(object):
         Arguments:
         ip_address -- an IP address in the standard string notation
         """
-        if not isinstance(ip_address, string_type):
+        if isinstance(ip_address,
+            (ipaddress.IPv4Address, ipaddress.IPv6Address)):
+            ip_address = str(ip_address)
+        elif not isinstance(ip_address, string_type):
             raise TypeError('argument 1 must be %s, not %s' %
                             (string_type_name, type(ip_address).__name__))
 

--- a/tests/reader_test.py
+++ b/tests/reader_test.py
@@ -3,6 +3,7 @@
 
 from __future__ import unicode_literals
 
+import ipaddress
 import logging
 import mock
 import os
@@ -125,9 +126,7 @@ class BaseTestReader(object):
     def test_ip_object_lookup(self):
         reader = open_database('tests/data/test-data/GeoIP2-City-Test.mmdb',
                                self.mode)
-        with self.assertRaisesRegex(TypeError,
-                                    "must be str(?:ing)?, not IPv6Address"):
-            reader.get(compat_ip_address('2001:220::'))
+        reader.get(compat_ip_address('2001:220::'))
         reader.close()
 
     def test_broken_database(self):
@@ -362,6 +361,11 @@ class BaseTestReader(object):
                 'found expected data record for ' + key_address + ' in ' +
                 file_name)
 
+            self.assertEqual(
+                data, reader.get(ipaddress.ip_address(key_address)),
+                'found expected data record for ' + key_address + ' in ' +
+                file_name)
+
         for ip in ['1.1.1.33', '255.254.253.123']:
             self.assertIsNone(reader.get(ip))
 
@@ -391,8 +395,14 @@ class BaseTestReader(object):
                              'found expected data record for ' + key_address +
                              ' in ' + file_name)
 
+            self.assertEqual({'ip': value_address},
+                             reader.get(ipaddress.ip_address(key_address)),
+                             'found expected data record for ' + key_address +
+                             ' in ' + file_name)
+
         for ip in ['1.1.1.33', '255.254.253.123', '89fa::']:
             self.assertIsNone(reader.get(ip))
+            self.assertIsNone(reader.get(ipaddress.ip_address(ip)))
 
 
 def has_maxminddb_extension():

--- a/tests/reader_test.py
+++ b/tests/reader_test.py
@@ -184,7 +184,7 @@ class BaseTestReader(object):
     def test_too_many_get_args(self):
         reader = open_database(
             'tests/data/test-data/MaxMind-DB-test-decoder.mmdb', self.mode)
-        self.assertRaises(TypeError, reader.get, ('1.1.1.1', 'blah'))
+        self.assertRaises(TypeError, reader.get, '1.1.1.1', 'blah')
         reader.close()
 
     def test_no_get_args(self):


### PR DESCRIPTION
This allows the user to provide an IP address in the form of an ipaddress.IPv4Address or ipaddress.IPv6Address as an argument for the "get" method.