### PR TITLE
Fix/issue 69

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -3,6 +3,11 @@
 History
 -------
 
+2.0.1 (2020-07-22)
+++++++++++++++++++
+
+* Fixing minimum required python version in setup.py.
+
 2.0.0 (2020-07-21)
 ++++++++++++++++++
 

--- a/maxminddb/__init__.py
+++ b/maxminddb/__init__.py
@@ -57,7 +57,7 @@ def Reader(database):  # pylint: disable=invalid-name
 
 
 __title__ = "maxminddb"
-__version__ = "2.0.0"
+__version__ = "2.0.1"
 __author__ = "Gregory Oschwald"
 __license__ = "Apache License, Version 2.0"
 __copyright__ = "Copyright 2013-2020 MaxMind, Inc."

--- a/setup.py
+++ b/setup.py
@@ -109,7 +109,7 @@ def run_setup(with_cext):
         packages=find_packages("."),
         package_data={"": ["LICENSE"]},
         package_dir={"maxminddb": "maxminddb"},
-        python_requires=">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*",
+        python_requires=">=3.6",
         include_package_data=True,
         install_requires=requirements,
         tests_require=["nose"],


### PR DESCRIPTION
## Description

The current version, which is stated to be Python 3 only, actually gets into Python 2 installations because of a missing python_requires update

This PR closes https://github.com/maxmind/MaxMind-DB-Reader-python/issues/69.

## Note

Also bumped the history and version number to help you prepare the new release. Of course, Yanking 2.0.0 would be needed to completely fix the issue, or I could update the PR to use a post version.