### PR TITLE
Add note about additional requirements.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -17,7 +17,9 @@ Installation
 If you want to use the C extension, you must first install `libmaxminddb
 <https://github.com/maxmind/libmaxminddb>`_ C library installed before
 installing this extension. If the library is not available, the module will
-fall-back to a pure Python implementation.
+fall-back to a pure Python implementation. Note that when installing the C
+library from a package, you may be required to install additonal packages
+containing build requirements such as `libmaxminddb-dev` on Debian.
 
 To install maxminddb, type:
 


### PR DESCRIPTION
Hello. I spent a few minutes tracking down why the extension was not being built for me. Turned out pip will silently fail to build the extension if `maxminddb.h` is missing. When installing `libmaxminddb` from a package, the header is included in a separate package. This is obvious, but the documentation seems to assume library installation via sources.

FWIW, I ran pip in verbose mode to get the build output / warning: `pip install -v maxminddb`.

I just added a note to the `README.rst` that may save someone some minutes in the future.