### PR TITLE
Improve type checking: return ‘Reader’ from open_database()

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -4,3 +4,4 @@ disable=C0330
 [BASIC]
 
 no-docstring-rgx=_.*
+extension-pkg-allow-list=maxminddb.extension

--- a/maxminddb/__init__.py
+++ b/maxminddb/__init__.py
@@ -20,6 +20,19 @@ from maxminddb.const import (
 from maxminddb.decoder import InvalidDatabaseError
 from maxminddb.reader import Reader as PyReader
 
+__all__ = [
+    "InvalidDatabaseError",
+    "MODE_AUTO",
+    "MODE_FD",
+    "MODE_FILE",
+    "MODE_MEMORY",
+    "MODE_MMAP",
+    "MODE_MMAP_EXT",
+    "PyReader",  # Exposed for type checking b/c return type of open_database()
+    "Reader",
+    "open_database",
+]
+
 
 def open_database(
     database: Union[AnyStr, int, os.PathLike, IO], mode: int = MODE_AUTO

--- a/maxminddb/__init__.py
+++ b/maxminddb/__init__.py
@@ -2,12 +2,7 @@
 import os
 from typing import IO, AnyStr, Union, cast
 
-try:
-    import maxminddb.extension
-except ImportError:
-    maxminddb.extension = None  # type: ignore
-
-from maxminddb.const import (
+from .const import (
     MODE_AUTO,
     MODE_FD,
     MODE_FILE,
@@ -15,8 +10,15 @@ from maxminddb.const import (
     MODE_MMAP,
     MODE_MMAP_EXT,
 )
-from maxminddb.decoder import InvalidDatabaseError
-from maxminddb.reader import Reader
+from .decoder import InvalidDatabaseError
+from .reader import Reader
+
+try:
+    # pylint: disable=import-self
+    from . import extension as _extension
+except ImportError:
+    _extension = None  # type: ignore[assignment]
+
 
 __all__ = [
     "InvalidDatabaseError",
@@ -60,7 +62,7 @@ def open_database(
     ):
         raise ValueError(f"Unsupported open mode: {mode}")
 
-    has_extension = maxminddb.extension and hasattr(maxminddb.extension, "Reader")
+    has_extension = _extension and hasattr(_extension, "Reader")
     use_extension = has_extension if mode == MODE_AUTO else mode == MODE_MMAP_EXT
 
     if not use_extension:
@@ -75,7 +77,7 @@ def open_database(
     # checking purposes, pretend it is one. (Ideally this would be a subclass
     # of, or share a common parent class with, the Python Reader
     # implementation.)
-    return cast(Reader, maxminddb.extension.Reader(database, mode))
+    return cast(Reader, _extension.Reader(database, mode))
 
 
 __title__ = "maxminddb"

--- a/tests/reader_test.py
+++ b/tests/reader_test.py
@@ -250,8 +250,8 @@ class BaseTestReader(object):
             self.assertEqual(reader.metadata().database_type, "MaxMind DB Decoder Test")
 
     def test_no_extension_exception(self):
-        real_extension = maxminddb.extension
-        maxminddb.extension = None
+        real_extension = maxminddb._extension
+        maxminddb._extension = None
         with self.assertRaisesRegex(
             ValueError,
             "MODE_MMAP_EXT requires the maxminddb.extension module to be available",
@@ -259,7 +259,7 @@ class BaseTestReader(object):
             open_database(
                 "tests/data/test-data/MaxMind-DB-test-decoder.mmdb", MODE_MMAP_EXT
             )
-        maxminddb.extension = real_extension
+        maxminddb._extension = real_extension
 
     def test_broken_database(self):
         reader = open_database(


### PR DESCRIPTION
This exposes the ‘Reader’ class under its own name (instead of an alias)
and uses it as the return type for open_database(). In case the C
extension is used, cast that to the same ‘Reader’ type for type checking
purposes, since they share an identical API.

The benefits are that this avoids an unnecessary Union return type
(see e.g. python/mypy#1693) and doesn't
require internal types to be exposed with confusing names for type
checking purposes only.

The ‘Reader’ compat helper is unnecessary and can be dropped: the Python
Reader is always available and API compatible.

While at it, simplify and isort the imports.