### PR TITLE
Remove unused mocket from test dependencies

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -21,6 +21,5 @@ python =
 [testenv]
 deps =
     pytest
-    mocket
 commands = pytest tests
 passenv = *


### PR DESCRIPTION
If I understand it correctly, all tests are passing without mocket for me and I don't see its usage anywhere in the codebase. So I believe it should be removed from test dependencies.