### PR TITLE
Vendor libmaxminddb and produce binary wheels

### DIFF
--- a/.github/workflows/address-sanitizer.yml
+++ b/.github/workflows/address-sanitizer.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Install dependencies
         run: |
               python -m pip install --upgrade pip
-              pip install setuptools tox tox-gh-actions
+              pip install setuptools tox tox-gh-actions wheel
 
       - name: Test with tox
         run: MM_FORCE_EXT_TESTS=1 tox

--- a/.github/workflows/address-sanitizer.yml
+++ b/.github/workflows/address-sanitizer.yml
@@ -19,9 +19,6 @@ jobs:
         with:
           submodules: true
 
-      - name: Install libmaxminddb
-        run: sudo apt install libmaxminddb-dev
-
       - name: Set up Python
         uses: actions/setup-python@v4
         with:

--- a/.github/workflows/address-sanitizer.yml
+++ b/.github/workflows/address-sanitizer.yml
@@ -33,6 +33,8 @@ jobs:
               pip install setuptools tox tox-gh-actions wheel
 
       - name: Test with tox
-        run: MM_FORCE_EXT_TESTS=1 tox
+        run: tox
         env:
           LD_PRELOAD: libasan.so.6
+          MAXMINDDB_REQUIRE_EXTENSION: 1
+          MM_FORCE_EXT_TESTS: 1

--- a/.github/workflows/clang-analyzer.yml
+++ b/.github/workflows/clang-analyzer.yml
@@ -30,7 +30,9 @@ jobs:
               pip install setuptools wheel
 
       - name: Build and run analyzer
-        run: scan-build --status-bugs python setup.py build
+        # We exclude extension/libmaxminddb/ as libmaxminddb has its own workflow
+        # for this and we are not able to correct any issues with that code here.
+        run: scan-build --exclude extension/libmaxminddb/ --status-bugs python setup.py build
         env:
           CFLAGS: "-Werror -Wall -Wextra"
           MAXMINDDB_REQUIRE_EXTENSION: 1

--- a/.github/workflows/clang-analyzer.yml
+++ b/.github/workflows/clang-analyzer.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Install dependencies
         run: |
               python -m pip install --upgrade pip
-              pip install setuptools
+              pip install setuptools wheel
 
       - name: Build and run analyzer
         run: CFLAGS="-Werror -Wall -Wextra" scan-build --status-bugs python setup.py build

--- a/.github/workflows/clang-analyzer.yml
+++ b/.github/workflows/clang-analyzer.yml
@@ -16,8 +16,8 @@ jobs:
         with:
           submodules: true
 
-      - name: Install libmaxminddb
-        run: sudo apt install clang-tools libmaxminddb-dev
+      - name: Install clang-tools
+        run: sudo apt install clang-tools
 
       - name: Set up Python
         uses: actions/setup-python@v4

--- a/.github/workflows/clang-analyzer.yml
+++ b/.github/workflows/clang-analyzer.yml
@@ -13,6 +13,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          submodules: true
 
       - name: Install libmaxminddb
         run: sudo apt install clang-tools libmaxminddb-dev
@@ -28,4 +30,7 @@ jobs:
               pip install setuptools wheel
 
       - name: Build and run analyzer
-        run: CFLAGS="-Werror -Wall -Wextra" scan-build --status-bugs python setup.py build
+        run: scan-build --status-bugs python setup.py build
+        env:
+          CFLAGS: "-Werror -Wall -Wextra"
+          MAXMINDDB_REQUIRE_EXTENSION: 1

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -44,7 +44,7 @@ jobs:
       run: |
             sudo apt install libmaxminddb-dev
             python -m pip install --upgrade pip
-            pip install setuptools
+            pip install setuptools wheel
 
     - run: python setup.py build
 

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -43,7 +43,6 @@ jobs:
 
     - name: Install dependencies
       run: |
-            sudo apt install libmaxminddb-dev
             python -m pip install --upgrade pip
             pip install setuptools wheel
 

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -20,6 +20,7 @@ jobs:
         # We must fetch at least the immediate parents so that if this is
         # a pull request then we can checkout the head.
         fetch-depth: 2
+        submodules: true
 
     # If this run was triggered by a pull request event, then checkout
     # the head of the pull request instead of the merge commit.
@@ -47,6 +48,8 @@ jobs:
             pip install setuptools wheel
 
     - run: python setup.py build
+      env:
+        MAXMINDDB_REQUIRE_EXTENSION: 1
 
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v2

--- a/.github/workflows/create-wheels.yml
+++ b/.github/workflows/create-wheels.yml
@@ -14,9 +14,13 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+        with:
+          submodules: true
 
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.16.2
+        env:
+          MAXMINDDB_REQUIRE_EXTENSION: 1
 
       - uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/create-wheels.yml
+++ b/.github/workflows/create-wheels.yml
@@ -1,0 +1,23 @@
+name: Create Wheels
+
+on: [push, pull_request]
+
+jobs:
+  build_wheels:
+    name: Build wheels on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        # The extension currently does not build on windows-latest.
+        # We have a follow-up story for that.
+        os: [ubuntu-latest, macos-latest]
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Build wheels
+        uses: pypa/cibuildwheel@v2.16.2
+
+      - uses: actions/upload-artifact@v2
+        with:
+          path: ./wheelhouse/*.whl

--- a/.github/workflows/create-wheels.yml
+++ b/.github/workflows/create-wheels.yml
@@ -20,6 +20,7 @@ jobs:
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.16.2
         env:
+          CIBW_BUILD_VERBOSITY: 1
           MAXMINDDB_REQUIRE_EXTENSION: 1
 
       - uses: actions/upload-artifact@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -44,7 +44,13 @@ jobs:
               pip install setuptools tox tox-gh-actions wheel
 
       - name: Build with Werror and Wall
-        run: CFLAGS="-Werror -Wall -Wextra" python setup.py build
+        run: python setup.py build
+        env:
+          CFLAGS: "-Werror -Wall -Wextra"
+          MAXMINDDB_REQUIRE_EXTENSION: 1
 
       - name: Test with tox
         run: MM_FORCE_EXT_TESTS=1 tox
+        env:
+          MAXMINDDB_REQUIRE_EXTENSION: 1
+          MM_FORCE_EXT_TESTS: 1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
         # We don't test on Windows currently due to issues
         # build libmaxminddb there.
         platform: [macos-latest, ubuntu-latest]
-        python-version: [3.7, 3.8, 3.9, "3.10", 3.11, 3.12]
+        python-version: [3.8, 3.9, "3.10", 3.11, 3.12]
 
     name: Python ${{ matrix.python-version }} on ${{ matrix.platform }}
     runs-on: ${{ matrix.platform }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,14 +25,6 @@ jobs:
         with:
           submodules: true
 
-      - name: Install libmaxminddb
-        run: sudo apt install libmaxminddb-dev
-        if: matrix.platform == 'ubuntu-latest'
-
-      - name: Install libmaxminddb
-        run: brew install libmaxminddb
-        if: matrix.platform == 'macos-latest'
-
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v4
         with:
@@ -49,8 +41,23 @@ jobs:
           CFLAGS: "-Werror -Wall -Wextra"
           MAXMINDDB_REQUIRE_EXTENSION: 1
 
-      - name: Test with tox
+      - name: Test with tox (vendored libmaxminddb)
         run: tox
         env:
           MAXMINDDB_REQUIRE_EXTENSION: 1
+          MM_FORCE_EXT_TESTS: 1
+
+      - name: Install libmaxminddb
+        run: sudo apt install libmaxminddb-dev
+        if: matrix.platform == 'ubuntu-latest'
+
+      - name: Install libmaxminddb
+        run: brew install libmaxminddb
+        if: matrix.platform == 'macos-latest'
+
+      - name: Test with tox (system libmaxminddb)
+        run: tox
+        env:
+          MAXMINDDB_REQUIRE_EXTENSION: 1
+          MAXMINDDB_USE_SYSTEM_LIBMAXMINDDB: 1
           MM_FORCE_EXT_TESTS: 1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Install dependencies
         run: |
               python -m pip install --upgrade pip
-              pip install setuptools tox tox-gh-actions
+              pip install setuptools tox tox-gh-actions wheel
 
       - name: Build with Werror and Wall
         run: CFLAGS="-Werror -Wall -Wextra" python setup.py build

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -50,7 +50,7 @@ jobs:
           MAXMINDDB_REQUIRE_EXTENSION: 1
 
       - name: Test with tox
-        run: MM_FORCE_EXT_TESTS=1 tox
+        run: tox
         env:
           MAXMINDDB_REQUIRE_EXTENSION: 1
           MM_FORCE_EXT_TESTS: 1

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "tests/data"]
 	path = tests/data
 	url = https://github.com/maxmind/MaxMind-DB
+[submodule "extension/libmaxminddb"]
+	path = extension/libmaxminddb
+	url = git@github.com:maxmind/libmaxminddb.git

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -14,6 +14,10 @@ History
   Jean-Baptiste Braun and others. GitHub #23.
 * The multiprocessing test now explicitly uses ``fork``. This allows it
   to run successfully on macOS. Pull request by Theodore Ni. GitHub #116.
+* A vendored copy of ``libmaxminddb`` will now be used by default when
+  building the extension. If you wish to continue using the system shared
+  library, you may set the ``MAXMINDDB_USE_SYSTEM_LIBMAXMINDDB`` environment
+  variable to a true value when building the extension. 
 * The C extension now builds on Python 3.13.
 * The C extension will now be built for PyPy.
 

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -6,6 +6,8 @@ History
 2.5.0
 ++++++++++++++++++
 
+* IMPORTANT: Python 3.8 or greater is required. If you are using an older
+  version, please use an earlier release.
 * The ``Reader`` class now implements the ``__iter__`` method. This will
   return an iterator that iterates over all records in the database,
   excluding repeated aliased of the IPv4 network. Requested by

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -15,6 +15,7 @@ History
 * The multiprocessing test now explicitly uses ``fork``. This allows it
   to run successfully on macOS. Pull request by Theodore Ni. GitHub #116.
 * The C extension now builds on Python 3.13.
+* The C extension will now be built for PyPy.
 
 2.4.0 (2023-06-28)
 ++++++++++++++++++

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,5 @@
 include HISTORY.rst README.rst LICENSE maxminddb/py.typed maxminddb/extension.pyi
+recursive-include extension/libmaxminddb/include *.h
+recursive-include extension/libmaxminddb/src *.c *.h
 recursive-include tests/ *.mmdb *.py *.raw
 graft docs/html

--- a/README.rst
+++ b/README.rst
@@ -101,7 +101,7 @@ invalid IP address or an IPv6 address in an IPv4 database.
 Requirements
 ------------
 
-This code requires Python 3.7+. Older versions are not supported. The C
+This code requires Python 3.8+. Older versions are not supported. The C
 extension requires CPython.
 
 Versioning

--- a/README.rst
+++ b/README.rst
@@ -14,13 +14,6 @@ subnets (IPv4 or IPv6).
 Installation
 ------------
 
-If you want to use the C extension, you must first install `libmaxminddb
-<https://github.com/maxmind/libmaxminddb>`_ C library installed before
-installing this extension. If the library is not available, the module will
-fall-back to a pure Python implementation. Note that when installing the C
-library from a package, you may be required to install additonal packages
-containing build requirements such as `libmaxminddb-dev` on Debian.
-
 To install maxminddb, type:
 
 .. code-block:: bash
@@ -33,6 +26,9 @@ source directory:
 .. code-block:: bash
 
     $ easy_install .
+
+The installer will attempt to build the C extension. If this fails, the
+module will fall-back to the pure Python implementation.
 
 Usage
 -----

--- a/dev-bin/release.sh
+++ b/dev-bin/release.sh
@@ -36,6 +36,7 @@ if [ -n "$(git status --porcelain)" ]; then
 fi
 
 perl -pi -e "s/(?<=__version__ = \").+?(?=\")/$version/gsm" maxminddb/__init__.py
+perl -pi -e "s/(?<=^version = \").+?(?=\")/$version/gsm" pyproject.toml
 
 echo $"Test results:"
 tox

--- a/extension/maxminddb.c
+++ b/extension/maxminddb.c
@@ -1,7 +1,7 @@
 #define PY_SSIZE_T_CLEAN
 #include <Python.h>
 #include <arpa/inet.h>
-#include "libmaxminddb/include/maxminddb.h"
+#include <maxminddb.h>
 #include <netinet/in.h>
 #include <structmember.h>
 #include <sys/socket.h>

--- a/extension/maxminddb.c
+++ b/extension/maxminddb.c
@@ -1,7 +1,7 @@
 #define PY_SSIZE_T_CLEAN
 #include <Python.h>
 #include <arpa/inet.h>
-#include <maxminddb.h>
+#include "libmaxminddb/include/maxminddb.h"
 #include <netinet/in.h>
 #include <structmember.h>
 #include <sys/socket.h>

--- a/extension/maxminddb_config.h
+++ b/extension/maxminddb_config.h
@@ -1,0 +1,1 @@
+/* This is just a placeholder. We configure everything in setup.py. */

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools", "setuptools-scm"]
+requires = ["setuptools", "setuptools-scm", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [project]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,9 +42,3 @@ Documentation = "https://maxminddb.readthedocs.org/"
 # src is showing up in our GitHub linting builds. It seems to
 # contain deps.
 extend-exclude = '^/src/'
-
-[tool.cibuildwheel.linux]
-before-all = "apt install libmaxminddb-dev"
-
-[tool.cibuildwheel.macos]
-before-all = "brew install libmaxminddb"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,3 +42,9 @@ Documentation = "https://maxminddb.readthedocs.org/"
 # src is showing up in our GitHub linting builds. It seems to
 # contain deps.
 extend-exclude = '^/src/'
+
+[tool.cibuildwheel.linux]
+before-all = "apt install libmaxminddb-dev"
+
+[tool.cibuildwheel.macos]
+before-all = "brew install libmaxminddb"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ classifiers = [
 ]
 
 [project.urls]
-Homepage = "http://www.maxmind.com/"
+Homepage = "https://www.maxmind.com/"
 Documentation = "https://maxminddb.readthedocs.org/"
 "Source Code" = "https://github.com/maxmind/MaxMind-DB-Reader-python"
 "Issue Tracker" = "https://github.com/maxmind/MaxMind-DB-Reader-python/issues"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,4 +1,42 @@
-# We should probably migrate most of setup.cfg here
+[build-system]
+requires = ["setuptools", "setuptools-scm"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "maxminddb"
+version = "2.4.0"
+description = "Reader for the MaxMind DB format"
+authors = [
+    {name = "Gregory Oschwald", email = "goschwald@maxmind.com"},
+]
+dependencies = [
+    "setuptools>=68.2.2",
+]
+requires-python = ">=3.8"
+readme = "README.rst"
+license = {text = "Apache License, Version 2.0"}
+classifiers = [
+    "Development Status :: 5 - Production/Stable",
+    "Environment :: Web Environment",
+    "Intended Audience :: Developers",
+    "Intended Audience :: System Administrators",
+    "License :: OSI Approved :: Apache Software License",
+    "Programming Language :: Python",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.8",
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Topic :: Internet",
+    "Topic :: Internet :: Proxy Servers",
+]
+
+[project.urls]
+Homepage = "http://www.maxmind.com/"
+Documentation = "https://maxminddb.readthedocs.org/"
+"Source Code" = "https://github.com/maxmind/MaxMind-DB-Reader-python"
+"Issue Tracker" = "https://github.com/maxmind/MaxMind-DB-Reader-python/issues"
 
 [tool.black]
 # src is showing up in our GitHub linting builds. It seems to

--- a/setup.cfg
+++ b/setup.cfg
@@ -18,7 +18,6 @@ classifiers =
     Intended Audience :: System Administrators
     License :: OSI Approved :: Apache Software License
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
@@ -38,7 +37,7 @@ package_dir =
 packages = maxminddb
 install_requires =
 include_package_data = True
-python_requires = >=3.7
+python_requires = >=3.8
 
 [wheel]
 universal = 1
@@ -47,18 +46,17 @@ universal = 1
 maxminddb = extension.pyi; py.typed
 
 [tox:tox]
-envlist = {py37,py38,py39,py310,py311,py312}-test,py312-{black,lint,flake8,mypy}
+envlist = {py38,py39,py310,py311,py312}-test,py312-{black,lint,flake8,mypy}
 
 [gh-actions]
 python =
-    3.7: py37
     3.8: py38
     3.9: py39
     3.10: py310
     3.11: py311
     3.12: py312,black,lint,flake8,mypy
 
-[testenv:{py37,py38,py39,py310,py311,py312}-test]
+[testenv:{py38,py39,py310,py311,py312}-test]
 deps = pytest
 commands = pytest tests
 passenv = *

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,34 +3,6 @@ extend-ignore = E203
 # black uses 88 : ¯\_(ツ)_/¯
 max-line-length = 88
 
-[metadata]
-name = maxminddb
-author = Gregory Oschwald
-author_email = goschwald@maxmind.com
-license = Apache License, Version 2.0
-description = Reader for the MaxMind DB format
-url = http://www.maxmind.com/
-long_description = file: README.rst
-classifiers =
-    Development Status :: 5 - Production/Stable
-    Environment :: Web Environment
-    Intended Audience :: Developers
-    Intended Audience :: System Administrators
-    License :: OSI Approved :: Apache Software License
-    Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.8
-    Programming Language :: Python :: 3.9
-    Programming Language :: Python :: 3.10
-    Programming Language :: Python :: 3.11
-    Programming Language :: Python :: 3.12
-    Programming Language :: Python
-    Topic :: Internet :: Proxy Servers
-    Topic :: Internet
-project_urls =
-    Documentation = https://maxminddb.readthedocs.org/
-    Source Code = https://github.com/maxmind/MaxMind-DB-Reader-python
-    Issue Tracker = https://github.com/maxmind/MaxMind-DB-Reader-python/issues
-
 [options]
 package_dir =
     maxminddb = maxminddb

--- a/setup.cfg
+++ b/setup.cfg
@@ -11,9 +11,6 @@ install_requires =
 include_package_data = True
 python_requires = >=3.8
 
-[wheel]
-universal = 1
-
 [options.package_data]
 maxminddb = extension.pyi; py.typed
 

--- a/setup.py
+++ b/setup.py
@@ -21,13 +21,32 @@ cmdclass = {}
 PYPY = hasattr(sys, "pypy_version_info")
 JYTHON = sys.platform.startswith("java")
 
-compile_args = ["-Wall", "-Wextra"]
+compile_args = ["-Wall", "-Wextra", "-Wno-unknown-pragmas"]
 
 ext_module = [
     Extension(
         "maxminddb.extension",
-        libraries=["maxminddb"],
-        sources=["extension/maxminddb.c"],
+        sources=[
+            "extension/maxminddb.c",
+            "extension/libmaxminddb/src/data-pool.c",
+            "extension/libmaxminddb/src/maxminddb.c",
+        ],
+        define_macros=[
+            ("HAVE_CONFIG_H", 0),
+            ("MMDB_LITTLE_ENDIAN", 1 if sys.byteorder == "little" else 0),
+            # We define these for maximum compatibility. The extension
+            # itself supports all variations currently, but probing to
+            # see what the compiler supports is a bit annoying to do
+            # here, and we aren't using uint128 for much.
+            ("MMDB_UINT128_USING_MODE", 0),
+            ("MMDB_UINT128_IS_BYTE_ARRAY", 1),
+            ("PACKAGE_VERSION", '"maxminddb-python"'),
+        ],
+        include_dirs=[
+            "extension",
+            "extension/libmaxminddb/include",
+            "extension/libmaxminddb/src",
+        ],
         extra_compile_args=compile_args,
     )
 ]
@@ -116,6 +135,8 @@ else:
     try:
         run_setup(True)
     except BuildFailed as exc:
+        if os.getenv("MAXMINDDB_REQUIRE_EXTENSION"):
+            raise exc
         status_msgs(
             exc.cause,
             "WARNING: The C extension could not be compiled, "

--- a/setup.py
+++ b/setup.py
@@ -125,7 +125,7 @@ def run_setup(with_cext):
     setup(version=VERSION, cmdclass=loc_cmdclass, **kwargs)
 
 
-if PYPY or JYTHON:
+if JYTHON:
     run_setup(False)
     status_msgs(
         "WARNING: Disabling C extension due to Python platform.",

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,10 @@ cmdclass = {}
 PYPY = hasattr(sys, "pypy_version_info")
 JYTHON = sys.platform.startswith("java")
 
-compile_args = ["-Wall", "-Wextra", "-Wno-unknown-pragmas"]
+if os.name == "nt":
+    compile_args = []
+else:
+    compile_args = ["-Wall", "-Wextra", "-Wno-unknown-pragmas"]
 
 ext_module = [
     Extension(

--- a/setup.py
+++ b/setup.py
@@ -26,33 +26,44 @@ if os.name == "nt":
 else:
     compile_args = ["-Wall", "-Wextra", "-Wno-unknown-pragmas"]
 
-ext_module = [
-    Extension(
-        "maxminddb.extension",
-        sources=[
-            "extension/maxminddb.c",
-            "extension/libmaxminddb/src/data-pool.c",
-            "extension/libmaxminddb/src/maxminddb.c",
-        ],
-        define_macros=[
-            ("HAVE_CONFIG_H", 0),
-            ("MMDB_LITTLE_ENDIAN", 1 if sys.byteorder == "little" else 0),
-            # We define these for maximum compatibility. The extension
-            # itself supports all variations currently, but probing to
-            # see what the compiler supports is a bit annoying to do
-            # here, and we aren't using uint128 for much.
-            ("MMDB_UINT128_USING_MODE", 0),
-            ("MMDB_UINT128_IS_BYTE_ARRAY", 1),
-            ("PACKAGE_VERSION", '"maxminddb-python"'),
-        ],
-        include_dirs=[
-            "extension",
-            "extension/libmaxminddb/include",
-            "extension/libmaxminddb/src",
-        ],
-        extra_compile_args=compile_args,
-    )
-]
+
+if os.getenv("MAXMINDDB_USE_SYSTEM_LIBMAXMINDDB"):
+    ext_module = [
+        Extension(
+            "maxminddb.extension",
+            libraries=["maxminddb"],
+            sources=["extension/maxminddb.c"],
+            extra_compile_args=compile_args,
+        )
+    ]
+else:
+    ext_module = [
+        Extension(
+            "maxminddb.extension",
+            sources=[
+                "extension/maxminddb.c",
+                "extension/libmaxminddb/src/data-pool.c",
+                "extension/libmaxminddb/src/maxminddb.c",
+            ],
+            define_macros=[
+                ("HAVE_CONFIG_H", 0),
+                ("MMDB_LITTLE_ENDIAN", 1 if sys.byteorder == "little" else 0),
+                # We define these for maximum compatibility. The extension
+                # itself supports all variations currently, but probing to
+                # see what the compiler supports is a bit annoying to do
+                # here, and we aren't using uint128 for much.
+                ("MMDB_UINT128_USING_MODE", 0),
+                ("MMDB_UINT128_IS_BYTE_ARRAY", 1),
+                ("PACKAGE_VERSION", '"maxminddb-python"'),
+            ],
+            include_dirs=[
+                "extension",
+                "extension/libmaxminddb/include",
+                "extension/libmaxminddb/src",
+            ],
+            extra_compile_args=compile_args,
+        )
+    ]
 
 # Cargo cult code for installing extension with pure Python fallback.
 # Taken from SQLAlchemy, but this same basic code exists in many modules.

--- a/setup.py
+++ b/setup.py
@@ -4,6 +4,8 @@ import sys
 
 from setuptools import setup, Extension
 from setuptools.command.build_ext import build_ext
+from wheel.bdist_wheel import bdist_wheel
+
 
 # These were only added to setuptools in 59.0.1.
 try:
@@ -96,10 +98,12 @@ def find_packages(location):
 
 def run_setup(with_cext):
     kwargs = {}
+    loc_cmdclass = cmdclass.copy()
     if with_cext:
         kwargs["ext_modules"] = ext_module
+        loc_cmdclass["bdist_wheel"] = bdist_wheel
 
-    setup(version=VERSION, cmdclass=cmdclass, **kwargs)
+    setup(version=VERSION, cmdclass=loc_cmdclass, **kwargs)
 
 
 if PYPY or JYTHON:


### PR DESCRIPTION
- Drop Python 3.7 support
- Move project metadata to pyproject.toml
- Add support for building bdist_wheel
- Add workflow to build wheels
- Vendor libmaxminddb
- Increase verbosity when building wheels
- Build extension on PyPy
- Exclude extension/libmaxminddb/ from clang static analysis
- Do not set compile_args on Windows
