### PR TITLE
Exclude dev config and scripts

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,4 @@
+exclude .* .github/**/* dev-bin/*
 include HISTORY.rst README.rst LICENSE maxminddb/py.typed maxminddb/extension.pyi
 recursive-include extension/libmaxminddb/include *.h
 recursive-include extension/libmaxminddb/src *.c *.h

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,9 @@ Documentation = "https://maxminddb.readthedocs.org/"
 "Source Code" = "https://github.com/maxmind/MaxMind-DB-Reader-python"
 "Issue Tracker" = "https://github.com/maxmind/MaxMind-DB-Reader-python/issues"
 
+[tool.setuptools.package-data]
+maxminddb = ["py.typed"]
+
 [tool.black]
 # src is showing up in our GitHub linting builds. It seems to
 # contain deps.


### PR DESCRIPTION
build seems to include everything by default for some reason.
