### PR TITLE
Don't require setuptools in prod dependencies in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools", "setuptools-scm", "wheel"]
+requires = ["setuptools>=68.2.2", "setuptools-scm", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [project]
@@ -8,9 +8,6 @@ version = "2.5.2"
 description = "Reader for the MaxMind DB format"
 authors = [
     {name = "Gregory Oschwald", email = "goschwald@maxmind.com"},
-]
-dependencies = [
-    "setuptools>=68.2.2",
 ]
 requires-python = ">=3.8"
 readme = "README.rst"


### PR DESCRIPTION
It's not required for production use, only for building. Instead, add the constraint part to `build_system -> requires` to save anyone having to ship setuptools in production builds.

Fixes #154.