### PR TITLE
Build releases on macOS 13 and 14

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [macos-latest, ubuntu-latest, windows-latest]
+        os: [macos-13, macos-14, ubuntu-latest, windows-latest]
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Apparently, `macos-latest` means macOS 12. We need to to build on 14
Apple silicon support.

Fixes #152.
