### PR TITLE
Upload binary wheels to PyPI again

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,6 @@ jobs:
           - linux-intel
           - macos-arm
           - macos-intel
-          - pyodide
           - windows-arm
           - windows-intel
         include:
@@ -52,9 +51,6 @@ jobs:
             # macos-14+ (including latest) are ARM64 runners
             runs-on: macos-latest
             archs: auto,universal2
-          - os: pyodide
-            runs-on: ubuntu-latest
-            platform: pyodide
           - os: windows-arm
             runs-on: windows-11-arm
           - os: windows-intel

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -87,7 +87,7 @@ jobs:
 
       - uses: actions/upload-artifact@v4
         with:
-          name: cibw-wheels-${{ matrix.os }}-${{ strategy.job-index }}
+          name: maxminddb-whl-${{ matrix.os }}-${{ strategy.job-index }}
           path: ./wheelhouse/*.whl
 
   build_sdist:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,6 +19,8 @@ jobs:
     strategy:
       matrix:
         os:
+          - android-arm
+          - android-intel
           - ios
           - linux-arm
           - linux-intel

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -3,6 +3,13 @@
 History
 -------
 
+2.8.1 (2025-07-25)
+++++++++++++++++++
+
+* When upgrading to ``cibuildwheel`` 3.0.0, we inadvertently changed the artifact
+  names, causing the wheels to not be uploaded to PyPI. This release fixes that.
+  There are no other code changes. Report by David Hotham. GitHub #225.
+
 2.8.0 (2025-07-25)
 ++++++++++++++++++
 

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -3,6 +3,13 @@
 History
 -------
 
+2.8.2 (2025-07-25)
+++++++++++++++++++
+
+* Pyodide binary wheels will no longer be built by default. It is not possible to
+  upload these to PyPI currently. We may consider reenabling them and putting them
+  on the GitHub Releases page in the future if there is interest.
+
 2.8.1 (2025-07-25)
 ++++++++++++++++++
 

--- a/maxminddb/__init__.py
+++ b/maxminddb/__init__.py
@@ -88,7 +88,7 @@ def open_database(
 
 
 __title__ = "maxminddb"
-__version__ = "2.8.1"
+__version__ = "2.8.2"
 __author__ = "Gregory Oschwald"
 __license__ = "Apache License, Version 2.0"
 __copyright__ = "Copyright 2013-2025 MaxMind, Inc."

--- a/maxminddb/__init__.py
+++ b/maxminddb/__init__.py
@@ -88,7 +88,7 @@ def open_database(
 
 
 __title__ = "maxminddb"
-__version__ = "2.8.0"
+__version__ = "2.8.1"
 __author__ = "Gregory Oschwald"
 __license__ = "Apache License, Version 2.0"
 __copyright__ = "Copyright 2013-2025 MaxMind, Inc."

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "maxminddb"
-version = "2.8.1"
+version = "2.8.2"
 description = "Reader for the MaxMind DB format"
 authors = [
     {name = "Gregory Oschwald", email = "goschwald@maxmind.com"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "maxminddb"
-version = "2.8.0"
+version = "2.8.1"
 description = "Reader for the MaxMind DB format"
 authors = [
     {name = "Gregory Oschwald", email = "goschwald@maxmind.com"},


### PR DESCRIPTION
Our `cibuildwheel` 3.0.0 configuration changed the artifact names,
causing them to not be uploaded.

Fixes #225.
