### PR TITLE
Don't use git@ for submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3,4 +3,4 @@
 	url = https://github.com/maxmind/MaxMind-DB
 [submodule "extension/libmaxminddb"]
 	path = extension/libmaxminddb
-	url = git@github.com:maxmind/libmaxminddb.git
+	url = https://github.com/maxmind/libmaxminddb


### PR DESCRIPTION
This makes `git clone --recurse-submodules` fail if it's run in an environment where an SSH key registered with GitHub isn't available. That seems unnecessary in this case, since the repository is public.