### PR TITLE
Release the GIL across libmaxminddb lookup calls

### DIFF
--- a/extension/maxminddb.c
+++ b/extension/maxminddb.c
@@ -442,9 +442,18 @@ static int get_record(PyObject *self, PyObject *args, PyObject **record) {
         return -1;
     }
 
+    // Release the GIL across the libmaxminddb tree walk. The walk only
+    // touches the read-only mmap and stack-local state, the rwlock is
+    // already held, and the module is declared Py_MOD_GIL_NOT_USED - so
+    // no Python state is accessed here. On systems where the mmdb's
+    // pages are not resident (cold cache, slow disk, memory pressure)
+    // an individual page-in can stall this call for seconds; without
+    // releasing the GIL, the entire interpreter stalls with it.
     int mmdb_error = MMDB_SUCCESS;
-    MMDB_lookup_result_s result =
-        MMDB_lookup_sockaddr(mmdb, ip_address, &mmdb_error);
+    MMDB_lookup_result_s result;
+    Py_BEGIN_ALLOW_THREADS
+    result = MMDB_lookup_sockaddr(mmdb, ip_address, &mmdb_error);
+    Py_END_ALLOW_THREADS
 
     if (mmdb_error != MMDB_SUCCESS) {
         reader_release_read_lock(reader);
@@ -478,8 +487,13 @@ static int get_record(PyObject *self, PyObject *args, PyObject **record) {
         return prefix_len;
     }
 
+    // Same reasoning as above: read the data section from the mmap
+    // without holding the GIL.
     MMDB_entry_data_list_s *entry_data_list = NULL;
-    int status = MMDB_get_entry_data_list(&result.entry, &entry_data_list);
+    int status;
+    Py_BEGIN_ALLOW_THREADS
+    status = MMDB_get_entry_data_list(&result.entry, &entry_data_list);
+    Py_END_ALLOW_THREADS
     if (status != MMDB_SUCCESS) {
         reader_release_read_lock(reader);
         char ipstr[INET6_ADDRSTRLEN] = {0};


### PR DESCRIPTION
## Summary

I've been running into some occasional long Python stalls across all threads and tracked them down to geoip lookups. I've found that a few `Py_BEGIN_ALLOW_THREADS`/`Py_END_ALLOW_THREADS` additions can prevent such stalls and greatly increase parallelism.

The lookup path - `Reader.get()` and `Reader.get_with_prefix_len()`, which back geoip2's `city()` / `country()` / etc. - holds the GIL across `MMDB_lookup_sockaddr` and `MMDB_get_entry_data_list`. Both walk the read-only mmap and touch no Python state, but if the relevant pages aren't resident - cold cache after start-up, slow EBS, memory pressure on a long-running process - a single page-fault inside the walk stalls *every* Python thread for the duration of the disk wait, not just the calling thread.

This patch wraps both calls in `Py_BEGIN_ALLOW_THREADS` / `Py_END_ALLOW_THREADS`. No change to fast-path behavior; on the slow path, only the calling thread waits.

## Why it's safe

- `Py_MOD_GIL_NOT_USED` is already declared (free-threaded build), so the maintainers have committed that this code is safe to run with no GIL.
- The `pthread_rwlock_t` read lock is acquired *before* the wrap and released after, so concurrent close/destroy can't pull `mmdb` out from under us.
- The wrapped sections touch only the mmap, the `MMDB_s` (immutable post-open), and stack-locals. No Python C-API calls inside.

## Measured effect

Microbenchmark with a 10ms `usleep` inserted into `get_record` (stand-in for a page-fault stall), 10 threads × 100 lookups:

| Variant                         | Wall-clock | Throughput | Effective parallelism |
|---------------------------------|-----------:|-----------:|----------------------:|
| Current (GIL held)              |    12.13 s |  82 ops/s  |               0.82×   |
| Patched (`Py_BEGIN_ALLOW_THREADS`) |    1.23 s | 815 ops/s  |               8.14×   |

For warm-cache lookups the per-call cost is dominated by tree-walk work, so the GIL release/acquire overhead is in the noise - bench numbers without the artificial sleep are identical between variants.

## Notes

- A third `MMDB_get_entry_data_list` call exists inside the iterator's `__iter__` path (around line 856 in 3.1.1). Same reasoning would apply, but it's a separate code path and I left it out of this PR to keep the change tightly scoped to the hot lookup path. Happy to follow up if you'd like it covered.
