### PR TITLE
Use 'GeoIP'/'GeoLite' branding in documentation

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -34,7 +34,7 @@ Usage
 -----
 
 To use this module, you must first download or create a MaxMind DB file. We
-provide `free GeoLite2 databases
+provide `free GeoLite databases
 <https://dev.maxmind.com/geoip/geolocate-an-ip/databases?lang=en>`_. These
 files must be decompressed with ``gunzip``.
 
@@ -58,7 +58,7 @@ file descriptor immediately after the ``Reader`` object is created.
 The ``open_database`` function returns a ``Reader`` object. To look up an IP
 address, use the ``get`` method on this object. The method will return the
 corresponding values for the IP address from the database (e.g., a dictionary
-for GeoIP2/GeoLite2 databases). If the database does not contain a record for
+for GeoIP/GeoLite databases). If the database does not contain a record for
 that IP address, the method will return ``None``.
 
 If you wish to also retrieve the prefix length for the record, use the

--- a/maxminddb/__init__.py
+++ b/maxminddb/__init__.py
@@ -45,7 +45,7 @@ def open_database(
     """Open a MaxMind DB database.
 
     Arguments:
-        database: A path to a valid MaxMind DB file such as a GeoIP2 database
+        database: A path to a valid MaxMind DB file such as a GeoIP database
                   file, or a file descriptor in the case of MODE_FD.
         mode: mode to open the database with. Valid mode are:
               * MODE_MMAP_EXT - use the C extension with memory map.

--- a/maxminddb/extension.pyi
+++ b/maxminddb/extension.pyi
@@ -25,7 +25,7 @@ class Reader:
         """Reader for the MaxMind DB file format.
 
         Arguments:
-            database: A path to a valid MaxMind DB file such as a GeoIP2 database
+            database: A path to a valid MaxMind DB file such as a GeoIP database
                       file, or a file descriptor in the case of MODE_FD.
             mode: mode to open the database with. The only supported modes are
                   MODE_AUTO and MODE_MMAP_EXT.

--- a/maxminddb/reader.py
+++ b/maxminddb/reader.py
@@ -54,7 +54,7 @@ class Reader:
         """Reader for the MaxMind DB file format.
 
         Arguments:
-            database: A path to a valid MaxMind DB file such as a GeoIP2 database
+            database: A path to a valid MaxMind DB file such as a GeoIP database
                       file, or a file descriptor in the case of MODE_FD.
             mode: mode to open the database with. Valid mode are:
                   * MODE_MMAP - read from memory map.


### PR DESCRIPTION
Updates prose/documentation to refer to the products as "GeoIP"/"GeoLite" instead of "GeoIP2"/"GeoLite2". Technical identifiers (packages, class names, .mmdb filenames, edition IDs, the geolite.info hostname, URLs) and test fixtures are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)